### PR TITLE
Stop non-numeric data being sent to Grafana

### DIFF
--- a/resources.js
+++ b/resources.js
@@ -155,7 +155,7 @@ function summarize_room_internal(room) {
     // Energy in a source when it resets (wasted/lost energy)
 
     let retval = {
-        room_name: room.name, // In case this gets taken out of context
+        //room_name: room.name, // In case this gets taken out of context
         controller_level,
         controller_progress,
         controller_needed,
@@ -168,7 +168,7 @@ function summarize_room_internal(room) {
         energy_cap,
         num_sources,
         source_energy,
-        mineral_type,
+        //mineral_type,
         mineral_amount,
         num_extractors,
         has_storage,


### PR DESCRIPTION
Quick fix to stop spamming the ScreepsPlus Grafana logs with NaN warnings.